### PR TITLE
Terraform Prod Release v1.11.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.10.19
+current_version = 1.11.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 1.10.19
+version: 1.11.0
 
 # Terraform Project 
 ![NBA ELT Pipeline Data Flow 2](https://github.com/jyablonski/aws_terraform/assets/16946556/89d1f3b1-7d70-4aa9-8a08-40c4860f4897)

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: 1.10.19
+version: 1.11.0

--- a/alarms.tf
+++ b/alarms.tf
@@ -34,6 +34,7 @@ module "ecs_task_alarm" {
     "lastStatus": [
       "STOPPED"
     ],
+    "clusterArn": ["${aws_ecs_cluster.jacobs_ecs_cluster.arn}"],
     "containers": {
       "exitCode": [
         {

--- a/alb.tf
+++ b/alb.tf
@@ -1,7 +1,14 @@
-resource "aws_lb" "graphql_alb" {
-  name               = "jyablonski-graphql-alb-dev"
-  internal           = false
+locals {
+  load_balancer_name = "shiny-alb"
   load_balancer_type = "application"
+  target_group_name  = "shiny-target-group"
+  target_type        = "instance"
+}
+
+resource "aws_lb" "shiny_alb" {
+  name               = local.load_balancer_name
+  internal           = false
+  load_balancer_type = local.load_balancer_type
   security_groups    = [aws_security_group.jacobs_task_security_group_tf.id]
   subnets = [
     aws_subnet.jacobs_public_subnet.id,
@@ -10,13 +17,10 @@ resource "aws_lb" "graphql_alb" {
 
   enable_deletion_protection = false
 
-  tags = {
-    Environment = "dev"
-  }
 }
 
-resource "aws_lb_listener" "graphql_alb_https_listener" {
-  load_balancer_arn = aws_lb.graphql_alb.arn
+resource "aws_lb_listener" "shiny_alb_https_listener" {
+  load_balancer_arn = aws_lb.shiny_alb.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
@@ -24,49 +28,44 @@ resource "aws_lb_listener" "graphql_alb_https_listener" {
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.graphql_alb_tg.arn
+    target_group_arn = aws_lb_target_group.shiny_alb_tg.arn
   }
 }
 
-resource "aws_lb_listener_certificate" "graphql_alb_certificate_attachment" {
-  listener_arn    = aws_lb_listener.graphql_alb_https_listener.arn
+resource "aws_lb_listener" "shiny_alb_http_listener" {
+  load_balancer_arn = aws_lb.shiny_alb.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener_certificate" "shiny_alb_certificate_attachment" {
+  listener_arn    = aws_lb_listener.shiny_alb_https_listener.arn
   certificate_arn = aws_acm_certificate.jacobs_website_cert.arn
+
+  depends_on = [
+    aws_lb_listener.shiny_alb_http_listener, aws_lb_listener.shiny_alb_https_listener
+  ]
 }
 
 resource "aws_lb_target_group" "shiny_alb_tg" {
-  name        = "jyablonski-rshiny-tg"
+  name        = local.target_group_name
   vpc_id      = aws_vpc.jacobs_vpc_tf.id
-  target_type = "instance"
-  port        = 8050
-  protocol    = "HTTPS"
+  target_type = local.target_type
+  port        = 3838
+  protocol    = "HTTP"
 
   health_check {
     enabled = true
     timeout = 29
   }
-}
-
-resource "aws_lb_target_group" "graphql_alb_tg" {
-  name        = "jyablonski-graphql-tg-dev"
-  vpc_id      = aws_vpc.jacobs_vpc_tf.id
-  target_type = "lambda"
-
-  health_check {
-    enabled = false
-    timeout = 29
-  }
-}
-
-resource "aws_lambda_permission" "allow_alb_graphql_execution" {
-  statement_id  = "AllowExecutionFromALB"
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.jacobs_graphql_api_lambda_function.function_name
-  principal     = "elasticloadbalancing.amazonaws.com"
-  source_arn    = aws_lb_target_group.graphql_alb_tg.arn
-}
-
-
-resource "aws_lb_target_group_attachment" "graphql_alb_attachment" {
-  target_group_arn = aws_lb_target_group.graphql_alb_tg.arn
-  target_id        = aws_lambda_function.jacobs_graphql_api_lambda_function.arn
 }

--- a/ecs_ec2.tf
+++ b/ecs_ec2.tf
@@ -1,6 +1,7 @@
 locals {
-  ecs_cluster_name = "jacobs-ecs-ec2-cluster"
-  user_data        = <<-EOT
+  ecs_cluster_name  = "jacobs-ecs-ec2-cluster"
+  ecs_key_pair_name = "ecs-ec2-cluster-key-pair"
+  user_data         = <<-EOT
     #!/bin/bash
     cat <<'EOF' >> /etc/ecs/ecs.config
     ECS_CLUSTER=${local.ecs_cluster_name}
@@ -103,12 +104,19 @@ resource "aws_ecs_cluster" "ecs_ec2_cluster" {
   }
 }
 
+resource "aws_key_pair" "ecs_cluster_key_pair" {
+  key_name   = local.ecs_key_pair_name
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDOeyO5NJJjnK6h9vF8NHOaUGZcdyNcs7kES9mbIb84wLF1nDmbF/THTMn1MPO8xksQxxq9m4c/GuUMs/r7UymeBEXqXcjcOKh7B2CjkEtnuUzYGAQ2cAtAB6jDMMRBia7U38a77Ks6h+pXw5Ri/LvCnPxBYeXOx41T6F4vQ9dSK/NSyLD3kejTDZ6ZhFvDKxutxaPW2E7OZeRqdxCjJ/eZNi4kC9C8Ypfp4qMmePS4WHMrOaqJP3b0W2XpWgnDFd0DUVD5YHUTwQ9F9rEqHp92CQJ2HgZAV89qHoKdItxaik9o/GKpDA67cpH2ytM6JV87XHeQ9+w39VWeAmDfUOJFtsQdDfZJ83m6mkpA7C41ivpOk0nsXiLkNOKkyJvdD5vqeMq8XnzmNuTtbyjuBHi5ylBPtS60gCRRvkRsqrbhw29GU57D3C/5J8EU2QVTiiqeo3NmdLs81jRuQfyEfJop1CRnGMO75ZgdR/remo91jBzHwhxbXwC7RcKXHJb9y3c="
+}
+
+
 # this is needed for the ASG to boot up ec2 instances used in the ECS Cluster
 # image template, the size of the instance, iam profile that the instance assumes, and the bootstrap ecs stuff.
 resource "aws_launch_template" "ecs_launch_template" {
   name_prefix   = "${local.ecs_cluster_name}-launch-template"
   image_id      = "ami-0fe5f366c083f59ca"
   instance_type = "t2.micro"
+  key_name      = aws_key_pair.ecs_cluster_key_pair.key_name
 
   user_data = base64encode(local.user_data)
 
@@ -127,6 +135,8 @@ resource "aws_autoscaling_group" "ecs_ec2_cluster_asg" {
   protect_from_scale_in = true
 
   vpc_zone_identifier = [aws_subnet.jacobs_public_subnet.id, aws_subnet.jacobs_public_subnet_2.id]
+
+  target_group_arns = [aws_lb_target_group.shiny_alb_tg.arn]
 
   launch_template {
     id      = aws_launch_template.ecs_launch_template.id
@@ -172,7 +182,7 @@ resource "aws_iam_role" "ecs_ec2_role_cs" {
   name = "${local.ecs_cluster_name}-cs-role"
 
   # Terraform's "jsonencode" function converts a
-  # arn:aws:sts::494531898010:assumed-role/AirflowS3Logs-cl4cd06hj01900t0hoszeaqm/botocore-session-1671228174
+  # campspot test
   assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -5,8 +5,8 @@ resource "aws_ecs_task_definition" "ecs_task_module" {
   task_role_arn            = var.ecs_task_role_arn
   cpu                      = var.ecs_cpu
   memory                   = var.ecs_memory
-  network_mode             = "awsvpc"
-  requires_compatibilities = ["FARGATE"]
+  network_mode             = var.ecs_network_mode
+  requires_compatibilities = [var.ecs_compatability]
 
   tags = {
     Name = var.ecs_id

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -75,3 +75,13 @@ variable "ecs_schedule" {
   type        = bool
   description = "Boolean which will additionally build Scheduling Resources if true, or only build the ECS Task Definition + Log Group if false"
 }
+
+variable "ecs_network_mode" {
+  type    = string
+  default = "awsvpc"
+}
+
+variable "ecs_compatability" {
+  type    = string
+  default = "FARGATE"
+}

--- a/shiny.tf
+++ b/shiny.tf
@@ -1,0 +1,45 @@
+locals {
+  shiny_service_name = "shiny_dashboard_prod"
+}
+
+resource "aws_ecs_service" "shiny_dashboard" {
+  name                               = local.shiny_service_name
+  cluster                            = aws_ecs_cluster.ecs_ec2_cluster.id
+  task_definition                    = module.shiny_ecs_module.ecs_task_definition_arn
+  desired_count                      = 1
+  deployment_minimum_healthy_percent = 1
+  deployment_maximum_percent         = 100
+  launch_type                        = "EC2"
+
+}
+
+module "nba_dashboard_repo" {
+  source              = "./modules/iam_github"
+  iam_role_name       = "nba-dashboard"
+  github_provider_arn = aws_iam_openid_connect_provider.github_provider.arn
+  github_repo         = "jyablonski/NBA-Dashboard"
+  iam_role_policy     = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:CompleteLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:InitiateLayerUpload",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:PutImage"
+            ],
+            "Resource": "arn:aws:ecr:${var.region}:${data.aws_caller_identity.current.account_id}:repository/${aws_ecr_repository.jacobs_repo.name}"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ecr:GetAuthorizationToken",
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+
+}

--- a/website.tf
+++ b/website.tf
@@ -153,13 +153,24 @@ resource "aws_route53_record" "jacobs_website_route53_record_www" {
   }
 }
 
-resource "aws_route53_record" "jacobs_website_route53_record_graphql" {
+# resource "aws_route53_record" "jacobs_website_route53_record_graphql" {
+#   zone_id = aws_route53_zone.jacobs_website_zone.zone_id
+#   name    = "graphql.${local.website_domain}"
+#   type    = "A"
+#   alias {
+#     name                   = aws_lb.graphql_alb.dns_name
+#     zone_id                = aws_lb.graphql_alb.zone_id
+#     evaluate_target_health = false
+#   }
+# }
+
+resource "aws_route53_record" "jacobs_website_route53_record_shiny" {
   zone_id = aws_route53_zone.jacobs_website_zone.zone_id
-  name    = "graphql.${local.website_domain}"
+  name    = "nbadashboard.${local.website_domain}"
   type    = "A"
   alias {
-    name                   = aws_lb.graphql_alb.dns_name
-    zone_id                = aws_lb.graphql_alb.zone_id
+    name                   = aws_lb.shiny_alb.dns_name
+    zone_id                = aws_lb.shiny_alb.zone_id
     evaluate_target_health = false
   }
 }
@@ -431,6 +442,18 @@ resource "aws_cloudfront_distribution" "jacobs_website_api_distribution" {
     max_ttl                  = 0
   }
 
+  ordered_cache_behavior {
+    path_pattern             = "/admin/feature_flags/create"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"] # have to be here or it fails
+    target_origin_id         = local.api_origin_id
+    cache_policy_id          = aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.origin_request_policy.id
+    viewer_protocol_policy   = "redirect-to-https"
+    min_ttl                  = 0
+    default_ttl              = 0
+    max_ttl                  = 0
+  }
 
   default_cache_behavior {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]


### PR DESCRIPTION
- Added Shiny Application Resources for `nbadashboard.jyablonski.dev`
  - Route53
  - ALB
  - Target Group
  - ECS Task Definition + Service
  - IAM GitHub Role for CI / CD
- Deprecated GraphQL Application at `graphql.jyablonski.dev`.  RIP
- Updated Cloudwatch PagerDuty Alarm to not trigger based on failures from Shiny App (ongoing memory leak issue right now).