### PR TITLE
Terraform Prod Release v1.11.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.11.1
+current_version = 1.11.2
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 1.11.1
+version: 1.11.2
 
 # Terraform Project 
 ![NBA ELT Pipeline Data Flow 2](https://github.com/jyablonski/aws_terraform/assets/16946556/89d1f3b1-7d70-4aa9-8a08-40c4860f4897)

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: 1.11.1
+version: 1.11.2

--- a/github.tf
+++ b/github.tf
@@ -3,7 +3,7 @@ resource "aws_iam_openid_connect_provider" "github_provider" {
   client_id_list = [
     "sts.amazonaws.com",
   ]
-  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1", "1c58a3a8518e8759bf075b76b750d4f2df264fcd"]
 }
 
 # ℹ️Note: When GitHub inevitably rotates the certificate for this service, the thumbprint_list value will need to be updated.


### PR DESCRIPTION
- Updated GitHub IDP Thumprint list.
  - Thumbprints are found on their [blog](https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/)