### PR TITLE
Terraform Prod Release v1.12.8

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.12.7
+current_version = 1.12.8
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Test Pipeline](https://github.com/jyablonski/aws_terraform/actions/workflows/test.yml/badge.svg) ![Deploy Pipeline](https://github.com/jyablonski/aws_terraform/actions/workflows/deploy.yml/badge.svg)
 
-version: 1.12.7
+version: 1.12.8
 
 # Terraform Project 
 ![nba_pipeline_diagram](https://github.com/jyablonski/aws_terraform/assets/16946556/1014c07a-1a32-48e2-a6d9-fc5cbce472ed)

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: 1.12.7
+version: 1.12.8

--- a/website.tf
+++ b/website.tf
@@ -520,6 +520,45 @@ resource "aws_cloudfront_distribution" "jacobs_website_api_distribution" {
     max_ttl                  = 0
   }
 
+  ordered_cache_behavior {
+    path_pattern             = "/logout"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"] # have to be here or it fails
+    target_origin_id         = local.api_origin_id
+    cache_policy_id          = aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.origin_request_policy.id
+    viewer_protocol_policy   = "redirect-to-https"
+    min_ttl                  = 0
+    default_ttl              = 0
+    max_ttl                  = 0
+  }
+
+  ordered_cache_behavior {
+    path_pattern             = "/schedule*"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"] # have to be here or it fails
+    target_origin_id         = local.api_origin_id
+    cache_policy_id          = aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.origin_request_policy.id
+    viewer_protocol_policy   = "redirect-to-https"
+    min_ttl                  = 0
+    default_ttl              = 0
+    max_ttl                  = 0
+  }
+
+  ordered_cache_behavior {
+    path_pattern             = "/reddit_comments*"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"] # have to be here or it fails
+    target_origin_id         = local.api_origin_id
+    cache_policy_id          = aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.origin_request_policy.id
+    viewer_protocol_policy   = "redirect-to-https"
+    min_ttl                  = 0
+    default_ttl              = 0
+    max_ttl                  = 0
+  }
+
   default_cache_behavior {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD"]


### PR DESCRIPTION
### Description
Added Cache Invalidation Stuff for new REST API Endpoints

## Added
- None

## Updated
- REST API Cloudfront Distribution for new Endpoints

## Deleted
- None