### PR TITLE
Terraform v1.13.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.12.18
+current_version = 1.13.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/.github/js/terraform-comment.js
+++ b/.github/js/terraform-comment.js
@@ -1,0 +1,62 @@
+module.exports = async ({ github, context }) => {
+    const author = process.env.COMMENT_AUTHOR
+    const title = process.env.COMMENT_TITLE
+
+    const { data: comments } = await github.rest.issues.listComments({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.issue.number,
+    })
+    const label = `## terraform \`${title}\``
+    const botComment = comments.find(comment => {
+        return comment.user.type === 'Bot' && comment.body.includes(label)
+    })
+
+    let body = process.env.COMMENT_BODY
+    if (body.includes('Your infrastructure matches the configuration')) {
+        body = ''
+    } else {
+        const index = body.indexOf('Terraform used the selected providers')
+        if (index >= 0) {
+            body = body.slice(index)
+        }
+    }
+
+    if (body.length > 80000) {
+        body = '# Content is too long to include in GitHub comment'
+    }
+
+    const output = `${label}
+  
+  \`\`\`hcl
+  ${body}
+  \`\`\`
+  
+  @${author}`
+
+    if (body != '') {
+        if (botComment) {
+            github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output
+            })
+        } else {
+            github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+            })
+        }
+    } else {
+        if (botComment) {
+            github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id
+            })
+        }
+    }
+}

--- a/.github/js/terraform-comment.js
+++ b/.github/js/terraform-comment.js
@@ -7,7 +7,7 @@ module.exports = async ({ github, context }) => {
         repo: context.repo.repo,
         issue_number: context.issue.number,
     })
-    const label = `## terraform \`${title}\``
+    const label = `## \`${title}\``
     const botComment = comments.find(comment => {
         return comment.user.type === 'Bot' && comment.body.includes(label)
     })

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
         with:
-          # terraform_version: 0.13.0:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,11 +11,11 @@ env:
 
 jobs:
   terraform:
-    name: "Terraform"
+    name: "Terraform Deploy"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const path = require('path');
-            const scriptPath = path.join(__dirname, '..', 'js', 'terraform-comment.js');
-            const script = require(scriptPath);
+            const script = require('./.github/js/terraform-comment.js');
             await script({github, context});

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
 env:
   TERRAFORM_VERSION: "1.5.7"
 
+permissions:
+  id-token: write
+  contents: write # Ensure that the workflow has permission to write to PR comments
 
 jobs:
   terraform:
@@ -18,14 +21,13 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          # terraform_version: 0.13.0:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
       - name: Terraform Format
         id: fmtmain
         run: terraform init
-      
+
       - name: Terraform Validate
         id: validate
         run: terraform validate -no-color
@@ -42,11 +44,11 @@ jobs:
           COMMENT_TITLE: "${{ github.workflow }}"
           COMMENT_AUTHOR: "${{ github.actor }}"
         with:
-          github-token: ${{ inputs.github-token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const script = require('${{ github.action_path }}/../../src/js/terraform-pr-comment.js')
             await script({github, context})
-      
+
       - uses: actions/github-script@0.9.0
         env:
           PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,15 +34,16 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color -out .planfile
-        continue-on-error: true
+        run: terraform plan
 
-      - name: Post PR comment
-        uses: borchero/terraform-plan-comment@v2
+      - name: Submit PR Comment
+        uses: actions/github-script@v7
+        env:
+          COMMENT_BODY: "${{ steps.plan.outputs.stdout }}"
+          COMMENT_TITLE: "${{ github.workflow }}"
+          COMMENT_AUTHOR: "${{ github.actor }}"
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          planfile: .planfile
-          
-      - name: Terraform Plan Status
-        if: steps.plan.outcome == 'failure'
-        run: exit 1
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const script = require('${{ github.action_path }}/../js/terraform-comment.js')
+            await script({github, context})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,14 @@ env:
 
 jobs:
   terraform:
-    name: "Terraform"
+    name: "Terraform Plan"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
         with:
           # terraform_version: 0.13.0:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
@@ -35,6 +35,18 @@ jobs:
         run: terraform plan -no-color
         continue-on-error: true
 
+      - name: Submit PR Comment
+        uses: actions/github-script@v7
+        env:
+          COMMENT_BODY: "${{ steps.plan.outputs.stdout }}"
+          COMMENT_TITLE: "${{ github.workflow }}"
+          COMMENT_AUTHOR: "${{ github.actor }}"
+        with:
+          github-token: ${{ inputs.github-token }}
+          script: |
+            const script = require('${{ github.action_path }}/../../src/js/terraform-pr-comment.js')
+            await script({github, context})
+      
       - uses: actions/github-script@0.9.0
         env:
           PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,43 +34,15 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color
+        run: terraform plan -no-color -out .planfile
         continue-on-error: true
 
-      - name: Submit PR Comment
-        uses: actions/github-script@v7
-        env:
-          COMMENT_BODY: "${{ steps.plan.outputs.stdout }}"
-          COMMENT_TITLE: "${{ github.workflow }}"
-          COMMENT_AUTHOR: "${{ github.actor }}"
+      - name: Post PR comment
+        uses: borchero/terraform-plan-comment@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const script = require('${{ github.action_path }}/../../src/js/terraform-pr-comment.js')
-            await script({github, context})
-
-      - uses: actions/github-script@0.9.0
-        env:
-          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
-            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
-            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
-            <details><summary>Show Plan</summary>
-            \`\`\`\n
-            ${process.env.PLAN}
-            \`\`\`
-            </details>
-            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            })
+          token: ${{ secrets.GITHUB_TOKEN }}
+          planfile: .planfile
+          
       - name: Terraform Plan Status
         if: steps.plan.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,5 +45,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const script = require('${{ github.action_path }}/../js/terraform-comment.js')
-            await script({github, context})
+            const path = require('path');
+            const scriptPath = path.join(__dirname, '..', 'js', 'terraform-comment.js');
+            const script = require(scriptPath);
+            await script({github, context});

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ env:
 permissions:
   id-token: write
   contents: write # Ensure that the workflow has permission to write to PR comments
+  pull-requests: write
 
 jobs:
   terraform:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Test Pipeline](https://github.com/jyablonski/aws_terraform/actions/workflows/test.yml/badge.svg) ![Deploy Pipeline](https://github.com/jyablonski/aws_terraform/actions/workflows/deploy.yml/badge.svg)
 
-version: 1.12.18
+version: 1.13.0
 
 # Terraform Project 
 ![nba_pipeline_diagram](https://github.com/jyablonski/aws_terraform/assets/16946556/1014c07a-1a32-48e2-a6d9-fc5cbce472ed)

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: 1.12.18
+version: 1.13.0

--- a/alb.tf
+++ b/alb.tf
@@ -5,71 +5,71 @@ locals {
   target_type        = "instance"
 }
 
-resource "aws_lb" "alb" {
-  name               = local.load_balancer_name
-  internal           = false
-  load_balancer_type = local.load_balancer_type
-  security_groups    = [aws_security_group.jacobs_task_security_group_tf.id]
-  subnets = [
-    aws_subnet.jacobs_public_subnet.id,
-    aws_subnet.jacobs_public_subnet_2.id
-  ]
+# resource "aws_lb" "alb" {
+#   name               = local.load_balancer_name
+#   internal           = false
+#   load_balancer_type = local.load_balancer_type
+#   security_groups    = [aws_security_group.jacobs_task_security_group_tf.id]
+#   subnets = [
+#     aws_subnet.jacobs_public_subnet.id,
+#     aws_subnet.jacobs_public_subnet_2.id
+#   ]
 
-  enable_deletion_protection = false
+#   enable_deletion_protection = false
 
-}
+# }
 
-resource "aws_lb_listener" "alb_https_listener" {
-  load_balancer_arn = aws_lb.alb.arn
-  port              = "443"
-  protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = aws_acm_certificate.jacobs_website_cert.arn
+# resource "aws_lb_listener" "alb_https_listener" {
+#   load_balancer_arn = aws_lb.alb.arn
+#   port              = "443"
+#   protocol          = "HTTPS"
+#   ssl_policy        = "ELBSecurityPolicy-2016-08"
+#   certificate_arn   = aws_acm_certificate.jacobs_website_cert.arn
 
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.alb_tg.arn
-  }
-}
+#   default_action {
+#     type             = "forward"
+#     target_group_arn = aws_lb_target_group.alb_tg.arn
+#   }
+# }
 
-resource "aws_lb_listener" "alb_http_listener" {
-  load_balancer_arn = aws_lb.alb.arn
-  port              = "80"
-  protocol          = "HTTP"
+# resource "aws_lb_listener" "alb_http_listener" {
+#   load_balancer_arn = aws_lb.alb.arn
+#   port              = "80"
+#   protocol          = "HTTP"
 
-  default_action {
-    type = "redirect"
+#   default_action {
+#     type = "redirect"
 
-    redirect {
-      port        = "443"
-      protocol    = "HTTPS"
-      status_code = "HTTP_301"
-    }
-  }
-}
+#     redirect {
+#       port        = "443"
+#       protocol    = "HTTPS"
+#       status_code = "HTTP_301"
+#     }
+#   }
+# }
 
-resource "aws_lb_listener_certificate" "alb_certificate_attachment" {
-  listener_arn    = aws_lb_listener.alb_https_listener.arn
-  certificate_arn = aws_acm_certificate.jacobs_website_cert.arn
+# resource "aws_lb_listener_certificate" "alb_certificate_attachment" {
+#   listener_arn    = aws_lb_listener.alb_https_listener.arn
+#   certificate_arn = aws_acm_certificate.jacobs_website_cert.arn
 
-  depends_on = [
-    aws_lb_listener.alb_http_listener, aws_lb_listener.alb_https_listener
-  ]
-}
+#   depends_on = [
+#     aws_lb_listener.alb_http_listener, aws_lb_listener.alb_https_listener
+#   ]
+# }
 
-resource "aws_lb_target_group" "alb_tg" {
-  name        = "dash-target-group"
-  vpc_id      = aws_vpc.jacobs_vpc_tf.id
-  target_type = local.target_type
-  port        = 9000
-  protocol    = "HTTP"
+# resource "aws_lb_target_group" "alb_tg" {
+#   name        = "dash-target-group"
+#   vpc_id      = aws_vpc.jacobs_vpc_tf.id
+#   target_type = local.target_type
+#   port        = 9000
+#   protocol    = "HTTP"
 
-  health_check {
-    enabled = true
-    timeout = 29
-  }
+#   health_check {
+#     enabled = true
+#     timeout = 29
+#   }
 
-  lifecycle {
-    create_before_destroy = true
-  }
-}
+#   lifecycle {
+#     create_before_destroy = true
+#   }
+# }

--- a/api_gateway.tf
+++ b/api_gateway.tf
@@ -78,6 +78,10 @@ resource "aws_lambda_function" "jacobs_lambda_dynamodb_function" {
     Name        = local.env_name_dynamodb
     Environment = local.env_type_dynamodb
   }
+
+  lifecycle {
+    ignore_changes = [source_code_hash]
+  }
 }
 
 resource "aws_api_gateway_rest_api" "jacobs_api_gateway" {

--- a/aws_nuke.yml
+++ b/aws_nuke.yml
@@ -6,4 +6,4 @@ account-blocklist:
 - "999999999999" # production
 
 accounts:
-  "288364792694": {} # jacobs_account
+  "717791819289": {} # jacobs_account

--- a/dash.tf
+++ b/dash.tf
@@ -2,16 +2,16 @@ locals {
   dash_service_name = "nba_elt_dashboard"
 }
 
-resource "aws_ecs_service" "dash_dashboard" {
-  name                               = local.dash_service_name
-  cluster                            = aws_ecs_cluster.ecs_ec2_cluster.id
-  task_definition                    = module.dash_ecs_module.ecs_task_definition_arn
-  desired_count                      = 1
-  deployment_minimum_healthy_percent = 1
-  deployment_maximum_percent         = 100
-  launch_type                        = "EC2"
+# resource "aws_ecs_service" "dash_dashboard" {
+#   name                               = local.dash_service_name
+#   cluster                            = aws_ecs_cluster.ecs_ec2_cluster.id
+#   task_definition                    = module.dash_ecs_module.ecs_task_definition_arn
+#   desired_count                      = 1
+#   deployment_minimum_healthy_percent = 1
+#   deployment_maximum_percent         = 100
+#   launch_type                        = "EC2"
 
-}
+# }
 
 module "nba_elt_dashboard_repo" {
   source              = "./modules/iam_github"

--- a/dbt.tf
+++ b/dbt.tf
@@ -11,3 +11,16 @@ module "dbt_s3_ci_module" {
     "${module.kimball_github_cicd.iam_role_arn}"
   ]
 }
+
+module "dbt_s3_docs_module" {
+  source                   = "./modules/s3"
+  bucket_name              = "nba-elt-dbt-docs"
+  bucket_acl               = "private"
+  is_versioning_enabled    = "Disabled"
+  prefix_expiration_name   = "*"
+  prefix_expiration_length = 765
+  s3_access_resources = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+    "${module.dbt_github_cicd.iam_role_arn}"
+  ]
+}

--- a/ecr_v2.tf
+++ b/ecr_v2.tf
@@ -1,0 +1,41 @@
+locals {
+  ecr_repos = [
+    "jyablonski/ecr-repo1",
+    "jyablonski/ecr-repo2"
+  ]
+}
+
+resource "aws_ecr_repository" "ecr_repos_v2" {
+  for_each             = { for repo in local.ecr_repos : repo => true }
+  name                 = each.key
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "ecr_repos_v2_policy" {
+  for_each   = { for repo in local.ecr_repos : repo => true }
+  repository = aws_ecr_repository.ecr_repos_v2[each.key].name
+
+  policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Remove Untagged Images after 1 Day",
+            "selection": {
+              "tagStatus": "untagged",
+              "countType": "sinceImagePushed",
+              "countUnit": "days",
+              "countNumber": 1
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}

--- a/github_iam.tf
+++ b/github_iam.tf
@@ -92,7 +92,9 @@ module "dbt_github_cicd" {
             "Effect": "Allow",
             "Resource": [
                 "${module.dbt_s3_ci_module.s3_bucket_arn}",
-                "${module.dbt_s3_ci_module.s3_bucket_arn}/*"
+                "${module.dbt_s3_ci_module.s3_bucket_arn}/*",
+                "${module.dbt_s3_docs_module.s3_bucket_arn}",
+                "${module.dbt_s3_docs_module.s3_bucket_arn}/*"
             ]
         }
     ]

--- a/graphql_agent.tf
+++ b/graphql_agent.tf
@@ -10,111 +10,111 @@ locals {
   graphql_lambda_name = "jacobs_graphql_agent_lambda"
 }
 
-resource "aws_sns_topic" "jacobs_graphql_sns_topic" {
-  name       = local.graphql_sns_name
-  fifo_topic = false
+# resource "aws_sns_topic" "jacobs_graphql_sns_topic" {
+#   name       = local.graphql_sns_name
+#   fifo_topic = false
 
-  tags = {
-    Name        = local.env_name_graphql
-    Environment = local.env_type_graphql
-  }
-}
+#   tags = {
+#     Name        = local.env_name_graphql
+#     Environment = local.env_type_graphql
+#   }
+# }
 
-resource "aws_iam_user" "jacobs_deta_user" {
-  name = "jacobs_deta_user"
+# resource "aws_iam_user" "jacobs_deta_user" {
+#   name = "jacobs_deta_user"
 
-  tags = {
-    Name        = local.env_name_graphql
-    Environment = local.env_type_graphql
-  }
-}
+#   tags = {
+#     Name        = local.env_name_graphql
+#     Environment = local.env_type_graphql
+#   }
+# }
 
-resource "aws_iam_user_policy" "jacobs_deta_user_policy" {
-  name = "jacobs-deta-user-policy"
-  user = aws_iam_user.jacobs_deta_user.name
+# resource "aws_iam_user_policy" "jacobs_deta_user_policy" {
+#   name = "jacobs-deta-user-policy"
+#   user = aws_iam_user.jacobs_deta_user.name
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "sns:Publish"
-      ],
-      "Effect": "Allow",
-      "Resource": "${aws_sns_topic.jacobs_graphql_sns_topic.arn}"
-    }
-  ]
-}
-EOF
-}
+#   policy = <<EOF
+# {
+#   "Version": "2012-10-17",
+#   "Statement": [
+#     {
+#       "Action": [
+#         "sns:Publish"
+#       ],
+#       "Effect": "Allow",
+#       "Resource": "${aws_sns_topic.jacobs_graphql_sns_topic.arn}"
+#     }
+#   ]
+# }
+# EOF
+# }
 
-resource "aws_sqs_queue" "jacobs_graphql_sqs_queue" {
-  name                       = local.graphql_sqs_name
-  delay_seconds              = 0
-  message_retention_seconds  = 86400 # 24 hrs boi
-  max_message_size           = 262144
-  visibility_timeout_seconds = 120
+# resource "aws_sqs_queue" "jacobs_graphql_sqs_queue" {
+#   name                       = local.graphql_sqs_name
+#   delay_seconds              = 0
+#   message_retention_seconds  = 86400 # 24 hrs boi
+#   max_message_size           = 262144
+#   visibility_timeout_seconds = 120
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-                "Service": "sns.amazonaws.com"
-            },
-      "Action": "sqs:SendMessage",
-      "Resource": "arn:aws:sqs:*:*:jacobs-graphql-agent-sqs",
-      "Condition": {
-        "ArnEquals": { "aws:SourceArn": "${aws_sns_topic.jacobs_graphql_sns_topic.arn}" }
-      }
-    }
-  ]
-}
-POLICY
+#   policy = <<POLICY
+# {
+#   "Version": "2012-10-17",
+#   "Statement": [
+#     {
+#       "Effect": "Allow",
+#       "Principal": {
+#                 "Service": "sns.amazonaws.com"
+#             },
+#       "Action": "sqs:SendMessage",
+#       "Resource": "arn:aws:sqs:*:*:jacobs-graphql-agent-sqs",
+#       "Condition": {
+#         "ArnEquals": { "aws:SourceArn": "${aws_sns_topic.jacobs_graphql_sns_topic.arn}" }
+#       }
+#     }
+#   ]
+# }
+# POLICY
 
-  tags = {
-    Name        = local.env_name_graphql
-    Environment = local.env_type_graphql
-  }
-}
+#   tags = {
+#     Name        = local.env_name_graphql
+#     Environment = local.env_type_graphql
+#   }
+# }
 
-resource "aws_cloudwatch_log_group" "jacobs_graphql_lambda_logs" {
-  name              = "/aws/lambda/${local.graphql_lambda_name}"
-  retention_in_days = 7
-}
+# resource "aws_cloudwatch_log_group" "jacobs_graphql_lambda_logs" {
+#   name              = "/aws/lambda/${local.graphql_lambda_name}"
+#   retention_in_days = 7
+# }
 
-resource "aws_iam_role" "jacobs_graphql_lambda_role" {
-  name        = "jacobs_graphql_lambda_role"
-  description = "Role created for AWS Lambda which processes messages in an SQS Queue"
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
-        Sid    = ""
-        Principal = {
-          Service = "lambda.amazonaws.com"
-        }
-      },
-    ]
-  })
-}
+# resource "aws_iam_role" "jacobs_graphql_lambda_role" {
+#   name        = "jacobs_graphql_lambda_role"
+#   description = "Role created for AWS Lambda which processes messages in an SQS Queue"
+#   assume_role_policy = jsonencode({
+#     Version = "2012-10-17"
+#     Statement = [
+#       {
+#         Action = "sts:AssumeRole"
+#         Effect = "Allow"
+#         Sid    = ""
+#         Principal = {
+#           Service = "lambda.amazonaws.com"
+#         }
+#       },
+#     ]
+#   })
+# }
 
-resource "aws_iam_role_policy_attachment" "jacobs_graphql_eventbridge_rule_policy" {
-  role       = aws_iam_role.jacobs_graphql_lambda_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEventBridgeFullAccess"
-}
+# resource "aws_iam_role_policy_attachment" "jacobs_graphql_eventbridge_rule_policy" {
+#   role       = aws_iam_role.jacobs_graphql_lambda_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/AmazonEventBridgeFullAccess"
+# }
 
-resource "aws_iam_role_policy_attachment" "jacobs_graphql_logs_policy" {
-  role       = aws_iam_role.jacobs_graphql_lambda_role.name
-  policy_arn = "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
-}
+# resource "aws_iam_role_policy_attachment" "jacobs_graphql_logs_policy" {
+#   role       = aws_iam_role.jacobs_graphql_lambda_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
+# }
 
-resource "aws_iam_role_policy_attachment" "jacobs_graphql_sqs_policy" {
-  role       = aws_iam_role.jacobs_graphql_lambda_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSQSFullAccess"
-}
+# resource "aws_iam_role_policy_attachment" "jacobs_graphql_sqs_policy" {
+#   role       = aws_iam_role.jacobs_graphql_lambda_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/AmazonSQSFullAccess"
+# }

--- a/graphql_api.tf
+++ b/graphql_api.tf
@@ -4,76 +4,76 @@ locals {
 
 }
 
-resource "aws_iam_role" "jacobs_graphql_api_lambda_role" {
-  name               = local.graphql_api_role_name
-  description        = "Role created for AWS Lambda GraphQL API"
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
+# resource "aws_iam_role" "jacobs_graphql_api_lambda_role" {
+#   name               = local.graphql_api_role_name
+#   description        = "Role created for AWS Lambda GraphQL API"
+#   assume_role_policy = <<EOF
+# {
+#   "Version": "2012-10-17",
+#   "Statement": [
+#     {
+#       "Effect": "Allow",
+#       "Principal": {
+#         "Service": "lambda.amazonaws.com"
+#       },
+#       "Action": "sts:AssumeRole"
+#     }
+#   ]
+# }
+# EOF
+# }
 
-resource "aws_iam_role_policy_attachment" "jacobs_graphql_api_lambda_role_attachment1" {
-  role       = aws_iam_role.jacobs_graphql_api_lambda_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AWSLambdaExecute"
-}
+# resource "aws_iam_role_policy_attachment" "jacobs_graphql_api_lambda_role_attachment1" {
+#   role       = aws_iam_role.jacobs_graphql_api_lambda_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/AWSLambdaExecute"
+# }
 
-# arn:aws:iam::aws:policy/AWSLambdaExecute
-resource "aws_cloudwatch_log_group" "jacobs_graphql_api_lambda_logs" {
-  name              = "/aws/lambda/${local.graphql_api_lambda_name}"
-  retention_in_days = 7
-}
+# # arn:aws:iam::aws:policy/AWSLambdaExecute
+# resource "aws_cloudwatch_log_group" "jacobs_graphql_api_lambda_logs" {
+#   name              = "/aws/lambda/${local.graphql_api_lambda_name}"
+#   retention_in_days = 7
+# }
 
-resource "aws_lambda_function" "jacobs_graphql_api_lambda_function" {
-  architectures = ["x86_64"]
-  function_name = local.graphql_api_lambda_name
-  role          = aws_iam_role.jacobs_graphql_api_lambda_role.arn
-  handler       = "main.handler"
-  runtime       = "python3.9"
-  memory_size   = 128
-  timeout       = 20
+# resource "aws_lambda_function" "jacobs_graphql_api_lambda_function" {
+#   architectures = ["x86_64"]
+#   function_name = local.graphql_api_lambda_name
+#   role          = aws_iam_role.jacobs_graphql_api_lambda_role.arn
+#   handler       = "main.handler"
+#   runtime       = "python3.9"
+#   memory_size   = 128
+#   timeout       = 20
 
-  # define s3 bucket + the key in that backup with the zip
-  # zip has BOTH the depencenies from requirements.txt and the application code itself.
-  s3_bucket = aws_s3_bucket.jacobs_bucket_tf_dev.id
-  s3_key    = "graphql/lambda_function.zip"
+#   # define s3 bucket + the key in that backup with the zip
+#   # zip has BOTH the depencenies from requirements.txt and the application code itself.
+#   s3_bucket = aws_s3_bucket.jacobs_bucket_tf_dev.id
+#   s3_key    = "graphql/lambda_function.zip"
 
-  environment {
-    variables = {
-      RDS_USER                    = "${var.jacobs_rds_user}",
-      RDS_PW                      = "${var.jacobs_rds_pw}",
-      RDS_SCHEMA                  = "nba_prod"
-      IP                          = "${aws_db_instance.jacobs_rds_tf.address}",
-      RDS_DB                      = "${var.jacobs_rds_db}"
-      OTEL_EXPORTER_OTLP_ENDPOINT = "${var.honeycomb_endpoint}"
-      OTEL_EXPORTER_OTLP_HEADERS  = "${var.honeycomb_headers}"
-      OTEL_SERVICE_NAME           = "graphql-prod"
-    }
-  }
+#   environment {
+#     variables = {
+#       RDS_USER                    = "${var.jacobs_rds_user}",
+#       RDS_PW                      = "${var.jacobs_rds_pw}",
+#       RDS_SCHEMA                  = "nba_prod"
+#       IP                          = "${aws_db_instance.jacobs_rds_tf.address}",
+#       RDS_DB                      = "${var.jacobs_rds_db}"
+#       OTEL_EXPORTER_OTLP_ENDPOINT = "${var.honeycomb_endpoint}"
+#       OTEL_EXPORTER_OTLP_HEADERS  = "${var.honeycomb_headers}"
+#       OTEL_SERVICE_NAME           = "graphql-prod"
+#     }
+#   }
 
-  depends_on = [aws_iam_role_policy_attachment.jacobs_graphql_api_lambda_role_attachment1,
-    aws_cloudwatch_log_group.jacobs_graphql_api_lambda_logs,
-  ]
-}
+#   depends_on = [aws_iam_role_policy_attachment.jacobs_graphql_api_lambda_role_attachment1,
+#     aws_cloudwatch_log_group.jacobs_graphql_api_lambda_logs,
+#   ]
+# }
 
-resource "aws_lambda_function_url" "jacobs_graphql_api_lambda_function_url" {
-  function_name      = aws_lambda_function.jacobs_graphql_api_lambda_function.function_name
-  authorization_type = "NONE"
+# resource "aws_lambda_function_url" "jacobs_graphql_api_lambda_function_url" {
+#   function_name      = aws_lambda_function.jacobs_graphql_api_lambda_function.function_name
+#   authorization_type = "NONE"
 
-  cors {
-    allow_credentials = false
-    allow_origins     = ["*"]
-    allow_methods     = ["GET", "POST"]
-    max_age           = 43200 # 12 hrs
-  }
-}
+#   cors {
+#     allow_credentials = false
+#     allow_origins     = ["*"]
+#     allow_methods     = ["GET", "POST"]
+#     max_age           = 43200 # 12 hrs
+#   }
+# }

--- a/postgresql.tf
+++ b/postgresql.tf
@@ -6,106 +6,106 @@
 # }
 
 ### DEV
-resource "postgresql_database" "nba_db_prod" {
-  # provider = postgresql.pg1
-  name = "nba_elt_pipeline_db"
-}
+# resource "postgresql_database" "nba_db_prod" {
+#   # provider = postgresql.pg1
+#   name = "nba_elt_pipeline_db"
+# }
 
-resource "postgresql_role" "dbt_role" {
-  name     = "dbt_role"
-  password = "${var.pg_role_pass}dbt"
-}
+# resource "postgresql_role" "dbt_role" {
+#   name     = "dbt_role"
+#   password = "${var.pg_role_pass}dbt"
+# }
 
-resource "postgresql_role" "python_scrape_role" {
-  name     = "python_scrape_role"
-  password = "${var.pg_role_pass}python"
-}
+# resource "postgresql_role" "python_scrape_role" {
+#   name     = "python_scrape_role"
+#   password = "${var.pg_role_pass}python"
+# }
 
-resource "postgresql_role" "shiny_read_role" {
-  name     = "shiny_read_role"
-  password = "${var.pg_role_pass}shiny"
-}
+# resource "postgresql_role" "shiny_read_role" {
+#   name     = "shiny_read_role"
+#   password = "${var.pg_role_pass}shiny"
+# }
 
-resource "postgresql_role" "rest_api_read_role" {
-  name     = "rest_api_read_role"
-  password = "${var.pg_role_pass}restapi"
-}
+# resource "postgresql_role" "rest_api_read_role" {
+#   name     = "rest_api_read_role"
+#   password = "${var.pg_role_pass}restapi"
+# }
 
-resource "postgresql_schema" "nba_source" {
-  name = "nba_source"
-  # owner    = postgresql_role.jacob_admin.name
-  database = postgresql_database.nba_db_prod.name
+# resource "postgresql_schema" "nba_source" {
+#   name = "nba_source"
+#   # owner    = postgresql_role.jacob_admin.name
+#   database = postgresql_database.nba_db_prod.name
 
-}
+# }
 
-resource "postgresql_schema" "nba_prod" {
-  name = "nba_prod"
-  # owner    = postgresql_role.jacob_admin.name
-  database = postgresql_database.nba_db_prod.name
+# resource "postgresql_schema" "nba_prod" {
+#   name = "nba_prod"
+#   # owner    = postgresql_role.jacob_admin.name
+#   database = postgresql_database.nba_db_prod.name
 
-}
+# }
 
-resource "postgresql_grant" "rest_api_read_access" {
-  database          = postgresql_database.nba_db_prod.name
-  role              = postgresql_role.rest_api_read_role.name
-  schema            = postgresql_schema.nba_prod.name
-  object_type       = "table"
-  objects           = [] # read access to everything in this schema.
-  privileges        = ["SELECT"]
-  with_grant_option = false
-}
+# resource "postgresql_grant" "rest_api_read_access" {
+#   database          = postgresql_database.nba_db_prod.name
+#   role              = postgresql_role.rest_api_read_role.name
+#   schema            = postgresql_schema.nba_prod.name
+#   object_type       = "table"
+#   objects           = [] # read access to everything in this schema.
+#   privileges        = ["SELECT"]
+#   with_grant_option = false
+# }
 
-resource "postgresql_grant" "shiny_read_access" {
-  database          = postgresql_database.nba_db_prod.name
-  role              = postgresql_role.shiny_read_role.name
-  schema            = postgresql_schema.nba_prod.name
-  object_type       = "table"
-  objects           = [] # read access to everything in this schema.
-  privileges        = ["SELECT"]
-  with_grant_option = false
-}
+# resource "postgresql_grant" "shiny_read_access" {
+#   database          = postgresql_database.nba_db_prod.name
+#   role              = postgresql_role.shiny_read_role.name
+#   schema            = postgresql_schema.nba_prod.name
+#   object_type       = "table"
+#   objects           = [] # read access to everything in this schema.
+#   privileges        = ["SELECT"]
+#   with_grant_option = false
+# }
 
-resource "postgresql_schema" "ml_models" {
-  name     = "ml_models"
-  database = postgresql_database.nba_db_prod.name
-}
+# resource "postgresql_schema" "ml_models" {
+#   name     = "ml_models"
+#   database = postgresql_database.nba_db_prod.name
+# }
 
-resource "postgresql_grant" "shiny_read_access_ml" {
-  database          = postgresql_database.nba_db_prod.name
-  role              = postgresql_role.shiny_read_role.name
-  schema            = postgresql_schema.ml_models.name
-  object_type       = "table"
-  objects           = [] # read access to everything in this schema.
-  privileges        = ["SELECT"]
-  with_grant_option = false
-}
+# resource "postgresql_grant" "shiny_read_access_ml" {
+#   database          = postgresql_database.nba_db_prod.name
+#   role              = postgresql_role.shiny_read_role.name
+#   schema            = postgresql_schema.ml_models.name
+#   object_type       = "table"
+#   objects           = [] # read access to everything in this schema.
+#   privileges        = ["SELECT"]
+#   with_grant_option = false
+# }
 
-resource "postgresql_schema" "ad_hoc_analytics" {
-  name     = "ad_hoc_analytics"
-  database = postgresql_database.nba_db_prod.name
-}
+# resource "postgresql_schema" "ad_hoc_analytics" {
+#   name     = "ad_hoc_analytics"
+#   database = postgresql_database.nba_db_prod.name
+# }
 
-resource "postgresql_schema" "nba_prep" {
-  name     = "nba_prep"
-  database = postgresql_database.nba_db_prod.name
-}
+# resource "postgresql_schema" "nba_prep" {
+#   name     = "nba_prep"
+#   database = postgresql_database.nba_db_prod.name
+# }
 
-resource "postgresql_schema" "nba_prod_jy" {
-  name     = "nba_prod_jy"
-  database = postgresql_database.nba_db_prod.name
-}
+# resource "postgresql_schema" "nba_prod_jy" {
+#   name     = "nba_prod_jy"
+#   database = postgresql_database.nba_db_prod.name
+# }
 
-resource "postgresql_schema" "nba_staging" {
-  name     = "nba_staging"
-  database = postgresql_database.nba_db_prod.name
-}
+# resource "postgresql_schema" "nba_staging" {
+#   name     = "nba_staging"
+#   database = postgresql_database.nba_db_prod.name
+# }
 
-resource "postgresql_schema" "operations" {
-  name     = "operations"
-  database = postgresql_database.nba_db_prod.name
-}
+# resource "postgresql_schema" "operations" {
+#   name     = "operations"
+#   database = postgresql_database.nba_db_prod.name
+# }
 
-resource "postgresql_schema" "snapshots" {
-  name     = "snapshots"
-  database = postgresql_database.nba_db_prod.name
-}
+# resource "postgresql_schema" "snapshots" {
+#   name     = "snapshots"
+#   database = postgresql_database.nba_db_prod.name
+# }

--- a/postgresql_test.tf
+++ b/postgresql_test.tf
@@ -1,30 +1,30 @@
 # 2024-01-30 - got this mf working baby
 # swap to this during next aws account swap to setup all rds infra
-module "postgres_db" {
-  source = "./modules/postgresql/database"
+# module "postgres_db" {
+#   source = "./modules/postgresql/database"
 
-  database_name  = "jacob_tester"
-  database_owner = var.jacobs_rds_user
-}
+#   database_name  = "jacob_tester"
+#   database_owner = var.jacobs_rds_user
+# }
 
-module "postgres_read" {
-  source        = "./modules/postgresql/role"
-  role_name     = "tester"
-  role_password = var.es_master_pw
-}
+# module "postgres_read" {
+#   source        = "./modules/postgresql/role"
+#   role_name     = "tester"
+#   role_password = var.es_master_pw
+# }
 
 
-module "reporting_schema" {
-  source = "./modules/postgresql/schema"
+# module "reporting_schema" {
+#   source = "./modules/postgresql/schema"
 
-  schema_name   = "reporting"
-  database_name = var.jacobs_rds_db
-  schema_owner  = var.jacobs_rds_user
+#   schema_name   = "reporting"
+#   database_name = var.jacobs_rds_db
+#   schema_owner  = var.jacobs_rds_user
 
-  read_access_roles  = ["nba_dashboard_user", module.postgres_read.role_name]
-  write_access_roles = []
-  admin_access_roles = [var.jacobs_rds_user]
-}
+#   read_access_roles  = ["nba_dashboard_user", module.postgres_read.role_name]
+#   write_access_roles = []
+#   admin_access_roles = [var.jacobs_rds_user]
+# }
 
 # module "postgres_admin" {
 #   source        = "./modules/postgresql/role"

--- a/providers.tf
+++ b/providers.tf
@@ -26,10 +26,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "5.11.0"
     }
-    postgresql = {
-      source  = "cyrilgdn/postgresql"
-      version = "~> 1.21.0"
-    }
+    # postgresql = {
+    #   source  = "cyrilgdn/postgresql"
+    #   version = "~> 1.21.0"
+    # }
     archive = {
       source  = "hashicorp/archive"
       version = "~> 2.3.0"
@@ -53,14 +53,16 @@ terraform {
 
 }
 
-provider "postgresql" {
-  # alias    = "pg1" - this fucks shit up for some reason yo
-  host      = var.pg_host
-  username  = var.pg_user
-  password  = var.pg_pass
-  sslmode   = "disable"
-  superuser = false
-}
+# provider "postgresql" {
+#   # alias    = "pg1" - this fucks shit up for some reason yo
+#   host             = var.pg_host
+#   username         = var.pg_user
+#   password         = var.pg_pass
+#   superuser        = false
+#   connect_timeout  = 15
+#   sslmode          = "disable"
+#   expected_version = "16.1"
+# }
 
 # provider "snowflake" {
 #   username    = var.snowflake_username

--- a/shiny.tf
+++ b/shiny.tf
@@ -103,13 +103,13 @@ resource "aws_lambda_function" "shiny_restart_lambda" {
   function_name = "${local.shiny_service_name}_lambda"
   role          = aws_iam_role.shiny_restart_role.arn
   handler       = "main.lambda_handler"
-  runtime       = "python3.9"
+  runtime       = "python3.11"
   memory_size   = 128
 
   source_code_hash = data.archive_file.lambda_shiny_restart_archive.output_base64sha256
 
   layers = [
-    "arn:aws:lambda:us-east-1:770693421928:layer:Klayers-p39-requests:11"
+    "arn:aws:lambda:us-east-1:770693421928:layer:Klayers-p311-requests-html:13"
   ]
 
   environment {
@@ -134,9 +134,9 @@ resource "aws_lambda_permission" "shiny_restart_lambda_permission" {
   source_arn    = aws_cloudwatch_event_rule.shiny_restart_rule.arn
 }
 
-resource "aws_cloudwatch_event_target" "shiny_restart_target" {
-  target_id = "shiny_restart_event_id"
-  arn       = aws_lambda_function.shiny_restart_lambda.arn
-  rule      = aws_cloudwatch_event_rule.shiny_restart_rule.name
+# resource "aws_cloudwatch_event_target" "shiny_restart_target" {
+#   target_id = "shiny_restart_event_id"
+#   arn       = aws_lambda_function.shiny_restart_lambda.arn
+#   rule      = aws_cloudwatch_event_rule.shiny_restart_rule.name
 
-}
+# }

--- a/shiny.tf
+++ b/shiny.tf
@@ -118,6 +118,10 @@ resource "aws_lambda_function" "shiny_restart_lambda" {
       ECS_EC2_CLUSTER = "${aws_ecs_cluster.ecs_ec2_cluster.arn}"
     }
   }
+
+  lifecycle {
+    ignore_changes = [source_code_hash]
+  }
 }
 
 resource "aws_cloudwatch_event_rule" "shiny_restart_rule" {

--- a/sns_trigger_adhoc.tf
+++ b/sns_trigger_adhoc.tf
@@ -136,6 +136,10 @@ resource "aws_lambda_function" "jacobs_adhoc_sns_ecs_lambda_function" {
     Name        = local.env_name_adhoc
     Environment = local.env_type_adhoc
   }
+
+  lifecycle {
+    ignore_changes = [source_code_hash]
+  }
 }
 
 resource "aws_sns_topic_subscription" "enable_adhoc_lambda_sns_ecs" {

--- a/website.tf
+++ b/website.tf
@@ -202,16 +202,16 @@ resource "aws_route53_record" "jacobs_website_route53_record_www" {
 #   }
 # }
 
-resource "aws_route53_record" "jacobs_website_route53_record_shiny" {
-  zone_id = aws_route53_zone.jacobs_website_zone.zone_id
-  name    = "nbadashboard.${local.website_domain}"
-  type    = "A"
-  alias {
-    name                   = aws_lb.alb.dns_name
-    zone_id                = aws_lb.alb.zone_id
-    evaluate_target_health = false
-  }
-}
+# resource "aws_route53_record" "jacobs_website_route53_record_shiny" {
+#   zone_id = aws_route53_zone.jacobs_website_zone.zone_id
+#   name    = "nbadashboard.${local.website_domain}"
+#   type    = "A"
+#   alias {
+#     name                   = aws_lb.alb.dns_name
+#     zone_id                = aws_lb.alb.zone_id
+#     evaluate_target_health = false
+#   }
+# }
 
 resource "aws_route53_record" "jacobs_website_route53_record_cert" {
   for_each = {


### PR DESCRIPTION
### Description
Swapped to new AWS Account, updated various resources, and removed any Services that now cost money because of hourly IPV4 Charges

## Added
- dbt Docs S3 Bucket
- ECR Repo paradigm to DRY some code up
- RDS Parameter Group + Version pin

## Updated
- Various Lambdas to include `ignore_changes = [source_code_hash]` so the Resources stop getting updated every `terraform plan`. These Lambdas won't ever get updated so this is probably fine.
- RDS is now `publicly_accessible = false` for cost saving purposes. 
  - Have to do followup work to get EC2 Bastion working to connect to this and use it.
  - Github Actions will no longer be able to connect to RDS anymore
  - REST API Lambda probably won't work as-is either.
- Shiny Dashboard Restart Lambda updated to Python 3.11, but it won't be used
- Terraform Plan Comment Action so that it spits out the entire Plan as a comment instead of a dropdown which was hard to view

## Deleted
- Various Resources were commented out for $$$ purposes:
  - ECS Service (for NBA Dashboard)
  - Application Load Balancer
  - Shiny Dashboard Restart Lambda Eventbridge Rule Trigger
  - Postgres Terraform Resources (becuase Terraform Cloud can't reach out to private RDS anymore)