### PR TITLE
feat(infra): add static site v2

### DIFF
--- a/doqs.tf
+++ b/doqs.tf
@@ -159,6 +159,12 @@ resource "aws_cloudfront_distribution" "doqs_distribution" {
     Environment = "production"
   }
 
+  lifecycle {
+    ignore_changes = [
+      origin,
+    ]
+  }
+
 }
 
 

--- a/modules/iam_github/README.md
+++ b/modules/iam_github/README.md
@@ -2,3 +2,5 @@
 Terraform Module to create IAM Roles that can only be assumed by GitHub Actions Runners to provide short-lived credentials during CI runs for access to AWS resources (S3, ECR etc).
 
 Only prerequisite is you have to create a `aws_iam_openid_connect_provider` resource for `https://token.actions.githubusercontent.com` and pass it a certificate.
+
+By default, the role trust policy allows any GitHub Actions subject for the provided repository (`repo:<owner>/<repo>:*`). Pass `github_sub` to scope the role to a specific branch, tag, environment, or other GitHub OIDC subject.

--- a/modules/iam_github/main.tf
+++ b/modules/iam_github/main.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "this" {
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:${var.github_repo}:*"]
+      values   = [coalesce(var.github_sub, "repo:${var.github_repo}:*")]
     }
   }
 }

--- a/modules/iam_github/variables.tf
+++ b/modules/iam_github/variables.tf
@@ -11,6 +11,12 @@ variable "github_repo" {
   description = "example format: jyablonski/kafka_faker_stream"
 }
 
+variable "github_sub" {
+  type        = string
+  default     = null
+  description = "Optional full GitHub OIDC sub claim. Defaults to repo:<github_repo>:*."
+}
+
 variable "iam_role_policy" {
   type = string
 }

--- a/website.tf
+++ b/website.tf
@@ -168,8 +168,8 @@ resource "aws_route53_record" "jacobs_website_route53_record" {
   name    = ""
   type    = "A"
   alias {
-    name                   = aws_cloudfront_distribution.jacobs_website_s3_distribution.domain_name
-    zone_id                = aws_cloudfront_distribution.jacobs_website_s3_distribution.hosted_zone_id
+    name                   = aws_cloudfront_distribution.website_v2.domain_name
+    zone_id                = aws_cloudfront_distribution.website_v2.hosted_zone_id
     evaluate_target_health = false
   }
 }
@@ -179,8 +179,8 @@ resource "aws_route53_record" "jacobs_website_route53_record_www" {
   name    = "www.${local.website_domain}"
   type    = "A"
   alias {
-    name                   = aws_cloudfront_distribution.jacobs_website_s3_distribution.domain_name
-    zone_id                = aws_cloudfront_distribution.jacobs_website_s3_distribution.hosted_zone_id
+    name                   = aws_cloudfront_distribution.website_v2.domain_name
+    zone_id                = aws_cloudfront_distribution.website_v2.hosted_zone_id
     evaluate_target_health = false
   }
 }
@@ -264,7 +264,7 @@ resource "aws_cloudfront_distribution" "jacobs_website_s3_distribution" {
     prefix          = "website"
   }
 
-  aliases = [local.website_domain, "www.${local.website_domain}"]
+  aliases = []
 
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]

--- a/website_v2.tf
+++ b/website_v2.tf
@@ -190,6 +190,12 @@ resource "aws_cloudfront_distribution" "website_v2" {
     Environment = "production"
   }
 
+  lifecycle {
+    ignore_changes = [
+      origin,
+    ]
+  }
+
   depends_on = [
     aws_cloudfront_distribution.jacobs_website_s3_distribution,
   ]

--- a/website_v2.tf
+++ b/website_v2.tf
@@ -1,0 +1,326 @@
+locals {
+  website_v2_bucket_name = "jyablonski-site"
+  website_v2_origin_id   = "jyablonski-site-origin"
+  website_v2_repo        = "jyablonski/site"
+}
+
+resource "aws_s3_bucket" "website_v2" {
+  bucket = local.website_v2_bucket_name
+
+  tags = {
+    Name        = local.website_v2_bucket_name
+    Environment = "production"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "website_v2" {
+  bucket = aws_s3_bucket.website_v2.id
+
+  versioning_configuration {
+    status = "Disabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "website_v2" {
+  bucket = aws_s3_bucket.website_v2.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_v2" {
+  bucket = aws_s3_bucket.website_v2.id
+
+  rule {
+    id     = "abort-incomplete-multipart-uploads"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "website_v2" {
+  bucket = aws_s3_bucket.website_v2.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "website_v2" {
+  bucket = aws_s3_bucket.website_v2.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_cloudfront_origin_access_control" "website_v2" {
+  name                              = "jyablonski-site-origin-access-control"
+  description                       = "Origin access control for the jyablonski/site static site"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_function" "website_v2_uri_rewrite" {
+  name    = "jyablonski-site-uri-rewrite"
+  runtime = "cloudfront-js-1.0"
+  comment = "Rewrite trailing-slash static site paths to index.html objects"
+  publish = true
+  code    = <<EOF
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+
+  if (uri.endsWith('/')) {
+    request.uri += 'index.html';
+  } else if (!uri.includes('.')) {
+    request.uri += '/index.html';
+  }
+
+  return request;
+}
+EOF
+}
+
+resource "aws_cloudfront_distribution" "website_v2" {
+  origin {
+    domain_name              = aws_s3_bucket.website_v2.bucket_regional_domain_name
+    origin_id                = local.website_v2_origin_id
+    origin_access_control_id = aws_cloudfront_origin_access_control.website_v2.id
+
+    s3_origin_config {
+      origin_access_identity = ""
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "jyablonski Site V2 Distribution"
+  default_root_object = "index.html"
+  price_class         = "PriceClass_200"
+  aliases             = [local.website_domain, "www.${local.website_domain}"]
+
+  custom_error_response {
+    error_code         = 403
+    response_code      = 404
+    response_page_path = "/404.html"
+  }
+
+  custom_error_response {
+    error_code         = 404
+    response_code      = 404
+    response_page_path = "/404.html"
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.website_v2_origin_id
+    compress         = true
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.website_v2_uri_rewrite.arn
+    }
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 300
+    max_ttl                = 86400
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "/_astro/*"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.website_v2_origin_id
+    compress         = true
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 31536000
+    max_ttl                = 31536000
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  logging_config {
+    include_cookies = false
+    bucket          = "jyablonski97-dev.s3.amazonaws.com"
+    prefix          = "website-v2"
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = aws_acm_certificate.jacobs_website_cert.arn
+    ssl_support_method  = "sni-only"
+  }
+
+  tags = {
+    Environment = "production"
+  }
+
+  depends_on = [
+    aws_cloudfront_distribution.jacobs_website_s3_distribution,
+  ]
+}
+
+data "aws_iam_policy_document" "website_v2_github" {
+  statement {
+    sid    = "S3DeployList"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.website_v2.arn,
+    ]
+  }
+
+  statement {
+    sid    = "S3DeployObjects"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = [
+      "${aws_s3_bucket.website_v2.arn}/*",
+    ]
+  }
+
+  statement {
+    sid    = "CloudFrontInvalidate"
+    effect = "Allow"
+    actions = [
+      "cloudfront:CreateInvalidation",
+    ]
+    resources = [
+      aws_cloudfront_distribution.website_v2.arn,
+    ]
+  }
+}
+
+module "website_v2_github_cicd" {
+  source              = "./modules/iam_github"
+  iam_role_name       = "jyablonski-site-github"
+  github_provider_arn = aws_iam_openid_connect_provider.github_provider.arn
+  github_repo         = local.website_v2_repo
+  github_sub          = "repo:${local.website_v2_repo}:ref:refs/heads/main"
+  iam_role_policy     = data.aws_iam_policy_document.website_v2_github.json
+}
+
+data "aws_iam_policy_document" "website_v2_bucket" {
+  statement {
+    sid    = "AllowGitHubDeployRole"
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [
+        module.website_v2_github_cicd.iam_role_arn,
+      ]
+    }
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.website_v2.arn,
+    ]
+  }
+
+  statement {
+    sid    = "AllowGitHubDeployObjects"
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [
+        module.website_v2_github_cicd.iam_role_arn,
+      ]
+    }
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = [
+      "${aws_s3_bucket.website_v2.arn}/*",
+    ]
+  }
+
+  statement {
+    sid    = "AllowCloudFrontReadAccess"
+    effect = "Allow"
+    principals {
+      type = "Service"
+      identifiers = [
+        "cloudfront.amazonaws.com",
+      ]
+    }
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = [
+      "${aws_s3_bucket.website_v2.arn}/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values = [
+        aws_cloudfront_distribution.website_v2.arn,
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "website_v2" {
+  bucket = aws_s3_bucket.website_v2.id
+  policy = data.aws_iam_policy_document.website_v2_bucket.json
+}
+
+output "website_v2_bucket_name" {
+  value = aws_s3_bucket.website_v2.id
+}
+
+output "website_v2_cloudfront_distribution_id" {
+  value = aws_cloudfront_distribution.website_v2.id
+}
+
+output "website_v2_cloudfront_domain_name" {
+  value = aws_cloudfront_distribution.website_v2.domain_name
+}
+
+output "website_v2_github_role_arn" {
+  value = module.website_v2_github_cicd.iam_role_arn
+}


### PR DESCRIPTION
### Description
Adds new private S3 and CloudFront infrastructure for the jyablonski/site static site, then prepares Route53 and CloudFront aliases for cutover from the old distribution.

## Added
- New website v2 bucket, CloudFront distribution, OAC, rewrite function, and GitHub deploy role.

## Updated
- GitHub IAM module supports an optional OIDC subject override for main-branch scoping.
- Existing website Route53 records now target the v2 distribution.